### PR TITLE
[fix] Fix typo on 01-webkit2-greeter.conf

### DIFF
--- a/modules/alter-lightdm/airootfs.x86_64/etc/lightdm/lightdm.conf.d/01-webkit2-greeter.conf
+++ b/modules/alter-lightdm/airootfs.x86_64/etc/lightdm/lightdm.conf.d/01-webkit2-greeter.conf
@@ -1,2 +1,2 @@
 [Seat:*]
-greeter-session=lightdm-webkir2-greeter
+greeter-session=lightdm-webkit2-greeter


### PR DESCRIPTION
`alter-lightdm`モジュールの lightdmの設定のタイポを直しました