### PR TITLE
[remove]ipw2100-fwとipw2200-fwを削除

### DIFF
--- a/modules/share/packages.i486/hardware.i486
+++ b/modules/share/packages.i486/hardware.i486
@@ -13,8 +13,6 @@
 
 #-- drivers --#
 b43-fwcutter
-ipw2100-fw
-ipw2200-fw
 sof-firmware
 
 #-- interface support --#

--- a/modules/share/packages.i686/hardware.i686
+++ b/modules/share/packages.i686/hardware.i686
@@ -13,8 +13,6 @@
 
 #-- drivers --#
 b43-fwcutter
-ipw2100-fw
-ipw2200-fw
 sof-firmware
 
 #-- interface support --#

--- a/modules/share/packages.pen4/hardware.pen4
+++ b/modules/share/packages.pen4/hardware.pen4
@@ -13,8 +13,6 @@
 
 #-- drivers --#
 b43-fwcutter
-ipw2100-fw
-ipw2200-fw
 sof-firmware
 
 #-- interface support --#

--- a/modules/share/packages.x86_64/hardware.x86_64
+++ b/modules/share/packages.x86_64/hardware.x86_64
@@ -13,8 +13,6 @@
 
 #-- drivers --#
 b43-fwcutter
-ipw2100-fw
-ipw2200-fw
 sof-firmware
 
 #-- interface support --#


### PR DESCRIPTION
`ipw2100-fw`と`ipw2100-fw`がリポジトリから消されているのでそれの対応。