### PR TITLE
Simulation mode doesn't use `_exit_code` local variable

### DIFF
--- a/tools/fullbuild.sh
+++ b/tools/fullbuild.sh
@@ -85,7 +85,6 @@ build() {
     if [[ ! -e "${fullbuild_dir}/fullbuild.${cha}_${arch}_${lang}" ]]; then
         if [[ "${simulation}" = true ]]; then
             echo "sudo bash build.sh ${_options[*]}"
-            _exit_code="${?}"
         else
             msg_info "Build the ${lang} version of ${cha} on the ${arch} architecture."
             sudo bash "${script_path}/build.sh" "${_options[@]}"


### PR DESCRIPTION
Fix below CI Filed.

https://github.com/FascodeNet/alterlinux/actions/runs/4922900814/jobs/8794133356

```
./tools/fullbuild.sh:88:25: warning: This $? refers to echo/printf, not a previous command.
Assign to variable to avoid it being overwritten. [SC2320]
```