### PR TITLE
[build] CIの追加 (Github Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         run: docker build -t alteriso5 .
 
       - name: Run Dockerfile
-        run: docker run --rm -v $(pwd):/mnt alteriso5
+        run: docker run --rm -v $(pwd):/mnt alteriso5 --privileged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         run: docker build -t alteriso5 .
 
       - name: Run Dockerfile
-        run: docker run -it --rm -v $(pwd):/mnt alteriso5
+        run: docker run --rm -v $(pwd):/mnt alteriso5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,5 @@ jobs:
 
       - name: Run Dockerfile
         run: docker run --privileged --rm -v $(pwd):/mnt alteriso5
+
+      # TODO: アーティファクトをアップロードする機能の実装

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         run: docker build -t alteriso5 .
 
       - name: Run Dockerfile
-        run: docker run --rm -v $(pwd):/mnt alteriso5 --privileged
+        run: docker run --privileged --rm -v $(pwd):/mnt alteriso5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# AlterISO5のビルドを行うGithub Actions
+
+name: build AlterISO5
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build Dockerfile
+        run: docker build -t alteriso5 .
+
+      - name: Run Dockerfile
+        run: docker run -it --rm -v $(pwd):/mnt alteriso5


### PR DESCRIPTION
## 変更内容

 - [x] ビルド用のGithub Actions CIを実装

## この変更によって何が変わるか

- コミット毎にCIでビルドを行う

## 注意点

ビルドしたisoをアップロードする処理は未実装です
現在開発段階ということもあり、意図的に未実装にしてあります。